### PR TITLE
drastically reduce execution times

### DIFF
--- a/docs/regridding/xesmf-h3.ipynb
+++ b/docs/regridding/xesmf-h3.ipynb
@@ -49,7 +49,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ds = xr.tutorial.open_dataset(\"air_temperature\", chunks={\"time\": 20})\n",
+    "ds = xr.tutorial.open_dataset(\"air_temperature\", chunks={\"time\": 20}).isel(\n",
+    "    time=slice(None, 400)\n",
+    ")\n",
     "ds"
    ]
   },
@@ -128,7 +130,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "computed = regridded.isel(time=slice(None, 100)).compute()\n",
+    "computed = regridded.compute()\n",
     "computed"
    ]
   },
@@ -236,21 +238,13 @@
    "id": "17",
    "metadata": {},
    "source": [
-    "# "
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "18",
-   "metadata": {},
-   "source": [
     "# curvilinear grid: the `ROMS_example` dataset"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -261,7 +255,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -274,7 +268,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -285,11 +279,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
-    "level = 8\n",
+    "level = 6\n",
     "geom = shapely.box(min_lon, min_lat, max_lon, max_lat)\n",
     "cell_ids = np.asarray(\n",
     "    h3ronpy.vector.geometry_to_cells(\n",
@@ -307,7 +301,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -319,7 +313,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -335,7 +329,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/regridding/xesmf-healpix.ipynb
+++ b/docs/regridding/xesmf-healpix.ipynb
@@ -49,7 +49,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ds = xr.tutorial.open_dataset(\"air_temperature\", chunks={\"time\": 20})\n",
+    "ds = xr.tutorial.open_dataset(\"air_temperature\", chunks={\"time\": 20}).isel(\n",
+    "    time=slice(None, 400)\n",
+    ")\n",
     "ds"
    ]
   },
@@ -122,7 +124,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "computed = regridded.isel(time=slice(None, 100)).compute()\n",
+    "computed = regridded.compute()\n",
     "computed"
    ]
   },
@@ -139,7 +141,9 @@
   {
    "cell_type": "markdown",
    "id": "10",
-   "metadata": {},
+   "metadata": {
+    "jp-MarkdownHeadingCollapsed": true
+   },
    "source": [
     "# curvilinear grid: the `rasm` dataset"
    ]
@@ -248,7 +252,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ds = xr.tutorial.open_dataset(\"ROMS_example\", chunks={\"time\": 1})\n",
+    "ds = xr.tutorial.open_dataset(\n",
+    "    \"ROMS_example\", chunks={\"time\": 1, \"eta_rho\": -1, \"xi_rho\": -1}\n",
+    ")\n",
     "ds"
    ]
   },
@@ -334,12 +340,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "regridded = (\n",
-    "    regridder.regrid_dataset(ds, keep_attrs=True, skipna=True)\n",
-    "    .dggs.decode()\n",
-    "    .compute()\n",
-    "    .where(lambda ds: ds.notnull(), drop=True)\n",
-    ")\n",
+    "regridded = regridder.regrid_dataset(\n",
+    "    ds, keep_attrs=True, skipna=True, na_thres=0.5\n",
+    ").dggs.decode()\n",
     "regridded"
    ]
   },
@@ -350,7 +353,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "regridded[\"salt\"].dggs.explore(alpha=0.8)"
+    "computed = regridded.compute().where(lambda ds: ds.notnull(), drop=True)\n",
+    "computed"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "computed[\"salt\"].dggs.explore(alpha=0.8)"
    ]
   }
  ],


### PR DESCRIPTION
The notebooks are executed sequentially right now, and especially the `xesmf`-`healpix` notebook used to take almost 3 minutes to compute.