### PR TITLE
disable the PR previews

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -68,7 +68,7 @@ jobs:
           name: github-pages
 
   preview:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && false
     runs-on: ubuntu-latest
 
     needs: build


### PR DESCRIPTION
I'm not sure how to get this to work with just the infrastructure of gh pages (while allowing previews for PRs from forks) so I'll disable the feature for now.