### PR TITLE
remove the broken polar-crossing curvilinear example

### DIFF
--- a/docs/regridding/grid-weights-healpix.ipynb
+++ b/docs/regridding/grid-weights-healpix.ipynb
@@ -16,12 +16,10 @@
    "outputs": [],
    "source": [
     "import astropy.coordinates\n",
-    "import cartopy.crs as ccrs\n",
     "import cdshealpix.nested\n",
     "import cf_xarray  # noqa: F401\n",
     "import geoarrow.rust.core as geoarrow\n",
     "import grid_weights.api as grid_weights\n",
-    "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "import xarray as xr\n",
     "import xdggs  # noqa: F401\n",
@@ -206,110 +204,6 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "14",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "computed[\"air\"].dggs.explore(alpha=0.8)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "15",
-   "metadata": {},
-   "source": [
-    "## curvilinear grid: the `rasm` dataset"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "16",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ds = xr.tutorial.open_dataset(\"rasm\", chunks={\"time\": 8})\n",
-    "ds"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "17",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fig, ax = plt.subplots(subplot_kw={\"projection\": ccrs.NorthPolarStereo()})\n",
-    "ds[\"Tair\"].isel(time=1).plot.pcolormesh(\n",
-    "    x=\"xc\", y=\"yc\", ax=ax, transform=ccrs.PlateCarree()\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "18",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "source_geoms_ = geoarrow.to_shapely(infer_cell_geometries(ds)).reshape((205, 275))\n",
-    "source_geoms = xr.DataArray(\n",
-    "    source_geoms_, dims=[\"y\", \"x\"], coords=ds[[\"xc\", \"yc\"]].coords\n",
-    ").chunk({\"x\": 140, \"y\": 110})\n",
-    "source_geoms"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "19",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "level = 8\n",
-    "lon = astropy.coordinates.Longitude(0, unit=\"degree\")\n",
-    "lat = astropy.coordinates.Latitude(90, unit=\"degree\")\n",
-    "cell_ids, _, _ = cdshealpix.nested.cone_search(\n",
-    "    lon, lat, depth=level, flat=True, radius=(90 - 16.5) << astropy.units.degree\n",
-    ")\n",
-    "\n",
-    "target_grid = (\n",
-    "    xr.Dataset(coords={\"cell_ids\": (\"cells\", cell_ids)})\n",
-    "    .dggs.decode({\"grid_name\": \"healpix\", \"level\": level, \"indexing_scheme\": \"nested\"})\n",
-    "    .dggs.assign_latlon_coords()\n",
-    ")\n",
-    "target_grid"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "20",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%time\n",
-    "algorithms = grid_weights.Algorithms.by_variable(ds, default=\"conservative\")\n",
-    "indexed_cells = grid_weights.create_index(source_geoms).query(\n",
-    "    target_geoms, methods=algorithms.unique()\n",
-    ")\n",
-    "weights = grid_weights.weights(source_geoms, target_geoms, indexed_cells)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "21",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "computed = regridded.isel(time=slice(None, 100)).compute()\n",
-    "computed"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [


### PR DESCRIPTION
`grid-weights` currently works in 2D cartesian, which means it can't work properly with data that requires considering the looping nature of round bodies (additionally, it uses shapely which fails on geometries that intersect / contain the dateline / poles.